### PR TITLE
Port build system to Meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ Changes in version 0.1.4:
 
 * Uploaded to GitHub: http://github.com/minorninth/libresample
 
-Usage notes:  
+Changes in version 0.1.5:
+
+* Added a new build system using Meson.
+
+Usage notes:
 
 - If the output buffer you pass is too small, resample_process
   may not use any input samples because its internal output
@@ -73,6 +77,21 @@ Usage notes:
   output samples might be between 7992 and 8008.  Do not
   assume that it will be exactly 8000.  If you need exactly
   8000 outputs, pad the input with extra zeros as necessary.
+
+Build instructions:
+
+libresample can be built with [Meson](https://mesonbuild.com/),
+with the standard Autotools `./configure && make`, or with the
+included Visual Studio 2005 project file.
+
+The Meson build should generally be preferred. In particular,
+it is strongly recommended that downstream distribution
+packagers use the Meson build system for reasons of
+interoperability, as it generates a pkg-config file, supports
+building a shared library, can automatically run the tests, and
+runs on both Unix-like platforms and Windows. The older Autotools
+build system is retained for projects that already embed it into
+their builds and systems that do not have Meson.
 
 License and warranty:
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,41 @@
+project(
+  'libresample',
+  'c',
+  meson_version : '>=1.3',
+  default_options : 'default_library=both',
+  version : '0.1.5',
+  license : 'BSD-3-Clause OR LGPL-2.1-or-later',
+  license_files : ['LICENSE-BSD.txt', 'LICENSE-LGPL.txt'],
+)
+
+cc = meson.get_compiler('c')
+
+configure_file(
+  output : 'config.h',
+  configuration : {
+    'HAVE_INTTYPES_H': cc.has_header('inttypes.h').to_int(),
+  },
+)
+config_inc = include_directories('.')
+
+libm_dep = cc.find_library('m', required : false)
+
+resample = library(
+  'resample',
+  'src/filterkit.c',
+  'src/resample.c',
+  'src/resamplesubs.c',
+  dependencies : [libm_dep],
+  include_directories : [config_inc],
+  vs_module_defs : 'src/resample.def',
+  version : meson.project_version(),
+  soversion : 1,
+  install : true,
+)
+
+install_headers('include/libresample.h')
+
+pkg = import('pkgconfig')
+pkg.generate(resample, name : 'libresample')
+
+subdir('tests')

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,13 @@
+option(
+  'resample-sndfile',
+  type : 'feature',
+  value : 'auto',
+  description : 'Build and install the resample-sndfile tool (depends on libsndfile)',
+)
+
+option(
+  'compareresample',
+  type : 'feature',
+  value : 'auto',
+  description : 'Build and install the compareresample tool (depends on libsamplerate)',
+)

--- a/src/resample.def
+++ b/src/resample.def
@@ -1,0 +1,6 @@
+EXPORTS
+   resample_open
+   resample_dup
+   resample_get_filter_width
+   resample_process
+   resample_close

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,35 @@
+testresample = executable(
+  'testresample',
+  'testresample.c',
+  dependencies : [libm_dep],
+  link_with : [resample],
+)
+test('testresample', testresample)
+
+sndfile_dep = dependency(
+  'sndfile',
+  required : get_option('resample-sndfile'),
+)
+if sndfile_dep.found()
+  resample_sndfile = executable(
+    'resample-sndfile',
+    'resample-sndfile.c',
+    dependencies : [sndfile_dep],
+    link_with : [resample],
+    install : true,
+  )
+endif
+
+samplerate_dep = dependency(
+  'samplerate',
+  required : get_option('compareresample'),
+)
+if samplerate_dep.found()
+  compareresample = executable(
+    'compareresample',
+    'compareresample.c',
+    dependencies : [libm_dep, samplerate_dep],
+    link_with : [resample],
+    install : true,
+  )
+endif


### PR DESCRIPTION
I was trying to use Debian’s [CMake build system patch](https://salsa.debian.org/debian/libresample/-/blob/6478f2d9b52ff55ff9c42e2e46394bf164c18169/debian/patches/1001_shlib-cmake.patch) but ran into issues because its `.pc` file doesn’t actually include the linker flags required to link the resulting library.

I messed around with it for a bit, but generating correct `.pc` files from CMake is actually way too hard. So instead I just rewrote the build system in Meson, which is much simpler and takes care of all the details for us.

I don’t really expect this to be merged given the project has been inactive for over a decade, but I wanted to put it up here if any downstreams are interested in it.

@jonassmedegaard This may interest you, either to adopt directly in Debian or at least as a notification that the resulting `.pc` files from your current patch are broken; it lacks the flags for linking, and passes ones that don’t make sense like `-ffile-prefix-map=/build/libresample-Yb23pu/libresample-0.1.3=.`. (It also seems like the `libresample.so` in the current package is a broken symbolic link to `libresample.so.1`, but maybe that’s just some Debian thing I don’t fully understand.)